### PR TITLE
Fix first line of package header

### DIFF
--- a/auto-async-byte-compile.el
+++ b/auto-async-byte-compile.el
@@ -1,4 +1,4 @@
-;;;; auto-async-byte-compile.el --- Automatically byte-compile when saved
+;;; auto-async-byte-compile.el --- Automatically byte-compile when saved
 ;; Time-stamp: <2012-03-23 06:40:14 rubikitch>
 
 ;; Copyright (C) 2010  rubikitch


### PR DESCRIPTION
"[Conventional Headers for Emacs Libraries](https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html#Library-Headers)" says the first line of a library header should be:

```
;;; filename --- description
```

Without this, package repositories - such as MELPA - can not find a valid description for this package.
